### PR TITLE
add local LLM support through ollama

### DIFF
--- a/main.go
+++ b/main.go
@@ -581,11 +581,15 @@ func callOpenAI(prompt string, runNumber int, totalRuns int, batchNumber int, to
 }
 
 func callOllama(prompt string, model string, runNumber int, totalRuns int, batchNumber int, totalBatches int) string {
-    apiURL := "http://localhost:11434/api/chat"
+    apiURL := os.Getenv("OLLAMA_API_URL")
+    if apiURL == "" {
+        apiURL = "http://localhost:11434/api/chat"
+    }
 
     requestBody, err := json.Marshal(map[string]interface{}{
         "model":   model,
         "stream": false,
+        "format": "json",
         "messages": []map[string]interface{}{
             {"role": "user", "content": prompt},
         },


### PR DESCRIPTION
This PR makes it possible to use raink with a local LLM using [ollama](https://github.com/ollama/ollama), one of the most popular LLM frontends*.

It adds a new `--ollama-model <model_name>` flag which when specified uses the default `http://localhost:11434/api/chat` API provided by ollama instead of OpenAI API. If unspecified, raink works as before.

For testing this change the `qwen2.5:14b` model was used, ollama supports all mainstream models and they can be found [here](https://ollama.com/library). It can replicated by installing ollama, running the `ollama run qwen2.5:14b` command and then running the tool with `--ollama-model qwen2.5:14b` argument.