### PR TITLE
Add CLI arg for maximum tokens to be processed in a batch

### DIFF
--- a/main.go
+++ b/main.go
@@ -372,7 +372,7 @@ func (r *Ranker) Rank(objects []Object, round int) []FinalResult {
 	return finalResults
 }
 
-// TODO: Also log the "round" number (i.e., the repeated recursion depth).
+// TODO: Also log the request/retry attempt number.
 func (r *Ranker) logFromApiCall(runNum, batchNum int, message string, args ...interface{}) {
 	formattedMessage := fmt.Sprintf("Round %d, Run %*d/%d, Batch %*d/%d: "+message, r.round, len(strconv.Itoa(r.cfg.NumRuns)), runNum, r.cfg.NumRuns, len(strconv.Itoa(r.numBatches)), batchNum, r.numBatches)
 	log.Printf(formattedMessage, args...)


### PR DESCRIPTION
Fixes #6.
Replaces #3, #5.

Adds a `-t` option: `Max tokens per batch (default 128000)`

```
go run main.go \
    -t 500 \
    -ratio .125 \
    -ollama-model phi4 \
    -f testdata/sentences.txt \
    -r 2 \
    -s 20 \
    -p 'Rank each of these items according to their relevancy to the concept of "time".'
```

@s0md3v, let me know if this is what you were looking for.